### PR TITLE
Adjust a few minor bits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,6 @@ RUN apt-get update && apt-get install -y \
       zip \
  && rm -rf /var/lib/apt/lists/*
 
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 0xb5dbd5925590a237
-
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
  && docker-php-ext-install gd mbstring mysql pdo_mysql zip
 
@@ -20,25 +18,28 @@ RUN pecl install APCu geoip
 
 ENV PIWIK_VERSION 2.16.0
 
-VOLUME /var/www/html/
-
 RUN curl -fsSL -o piwik.tar.gz \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz" \
  && curl -fsSL -o piwik.tar.gz.asc \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz.asc" \
- && gpg --verify piwik.tar.gz.asc \
+ && export GNUPGHOME="$(mktemp -d)" \
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237 \
+ && gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz \
+ && rm -r "$GNUPGHOME" piwik.tar.gz.asc \
  && tar -xzf piwik.tar.gz -C /usr/src/ \
- && rm piwik.tar.gz piwik.tar.gz.asc \
+ && rm piwik.tar.gz \
  && chfn -f 'Piwik Admin' www-data
 
 COPY php.ini /usr/local/etc/php/php.ini
 
-RUN cd /usr/src/piwik/misc \
- && curl http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz > GeoLiteCity.dat.gz \
- && gunzip GeoLiteCity.dat.gz \
- && mv GeoLiteCity.dat GeoIPCity.dat
+RUN curl -fsSL -o /usr/src/piwik/misc/GeoIPCity.dat.gz http://geolite.maxmind.com/download/geoip/database/GeoLiteCity.dat.gz \
+ && gunzip /usr/src/piwik/misc/GeoIPCity.dat.gz
 
 COPY docker-entrypoint.sh /entrypoint.sh
+
+# WORKDIR is /var/www/html (inhertied via "FROM php")
+# "/entrypoint.sh" will populate it at container startup from /usr/src/piwik
+VOLUME /var/www/html
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-if [ ! -e '/var/www/html/piwik.php' ]; then
+if [ ! -e piwik.php ]; then
 	tar cf - --one-file-system -C /usr/src/piwik . | tar xf -
-	chown -R www-data /var/www/html
+	chown -R www-data .
 fi
 
 exec "$@"


### PR DESCRIPTION
1. update GPG usage ala https://github.com/docker-library/official-images/pull/1420
2. simplify "GeoIP" download and ensure download failure will be obvious (eases debugging)
3. move the `VOLUME` definition down to avoid creating additional volumes during build (adding a comment for additional clarity)
4. adjust the entrypoint to consistently assume `/var/www/html` is the current directory (instead of only assuming so for the `tar` line)

Overall really minor stuff; we're almost there! :smile: (thanks for hanging in)