### PR TITLE
Allow build to work behind strict firewall.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN curl -fsSL -o piwik.tar.gz \
  && curl -fsSL -o piwik.tar.gz.asc \
       "https://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz.asc" \
  && export GNUPGHOME="$(mktemp -d)" \
- && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237 \
+ && gpg --keyserver hkp://ha.pool.sks-keyservers.net:80/ --recv-keys 814E346FA01A20DBB04B6807B5DBD5925590A237 \
  && gpg --batch --verify piwik.tar.gz.asc piwik.tar.gz \
  && rm -r "$GNUPGHOME" piwik.tar.gz.asc \
  && tar -xzf piwik.tar.gz -C /usr/src/ \


### PR DESCRIPTION
This is just a minor tweak  to use the keyserver on port 80.