### PR TITLE
Add opcache php extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
 	&& docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
- 	&& docker-php-ext-install -j$(nproc) gd mbstring mysql pdo_mysql zip ldap
+ 	&& docker-php-ext-install -j$(nproc) gd mbstring mysql pdo_mysql zip ldap opcache
 
 RUN pecl install APCu geoip
 


### PR DESCRIPTION
As per the optimizing docs, https://piwik.org/docs/optimize-how-to/#configure-piwik-for-speed:
"It is critical to use a PHP cache for high performance. Fortunately, PHP5 and newer versions such as PHP 7 come with this PHP cache included by default."

However, the php-fpm docker containers don't come with opcache by default.