### PR TITLE
Remove explicit VOLUME creation in dockerfile

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -83,7 +83,6 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")
 # "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -93,9 +93,6 @@ COPY php.ini /usr/local/etc/php/conf.d/php-matomo.ini
 
 COPY docker-entrypoint.sh /entrypoint.sh
 
-# WORKDIR is /var/www/html (inherited via "FROM php")
-# "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["%%CMD%%"]

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -95,7 +95,7 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")
 # "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
+
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/fpm-alpine/Dockerfile
+++ b/fpm-alpine/Dockerfile
@@ -83,7 +83,7 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")
 # "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
+
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -95,7 +95,7 @@ COPY docker-entrypoint.sh /entrypoint.sh
 
 # WORKDIR is /var/www/html (inherited via "FROM php")
 # "/entrypoint.sh" will populate it at container startup from /usr/src/matomo
-VOLUME /var/www/html
+
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]


### PR DESCRIPTION
Removed explicit VOLUME /var/www/html from Dockerfiles.

This avoids automatic anonymous volume creation.
Users can define volumes explicitly using docker run or docker-compose.